### PR TITLE
Fix URLSearchParams issue

### DIFF
--- a/src/react-query-params.js
+++ b/src/react-query-params.js
@@ -128,11 +128,15 @@ export default class ReactQueryParams extends Component {
     if (source.location.query) {
       searchParams = source.location.query;
     } else if (source.location.search) {
-      const urlSearch = new URLSearchParams(source.location.search);
-
-      for (let pair of urlSearch) {
-        searchParams[pair[0]] = pair[1];
-      }
+      const queryString = (source.location.search || '').replace('?', '');
+      
+      searchParams = queryString.split('&')
+	      .filter(pair => !!pair && ~pair.indexOf('='))
+        .map(pair => pair.split('='))
+        .reduce((aggregated, current = []) => {  
+          aggregated[current[0]] = current[1];
+          return aggregated;
+        }, searchParams);
     }
     return searchParams;
   }

--- a/src/react-query-params.js
+++ b/src/react-query-params.js
@@ -131,7 +131,7 @@ export default class ReactQueryParams extends Component {
       const queryString = (source.location.search || '').replace('?', '');
       
       searchParams = queryString.split('&')
-	      .filter(pair => !!pair && ~pair.indexOf('='))
+	.filter(pair => !!pair && ~pair.indexOf('='))
         .map(pair => pair.split('='))
         .reduce((aggregated, current = []) => {  
           aggregated[current[0]] = current[1];


### PR DESCRIPTION
`URLSearchParams` has pretty poor browser support. It isn't supported by Edge and Internet Explorer at all and throws an error in those browsers. In fact, the plugin does not work there and may even break entire app.

I replaced it with more cross-browser implementation, which has been tested and works fine for me.