### PR TITLE
Add params encoding

### DIFF
--- a/src/react-query-params.js
+++ b/src/react-query-params.js
@@ -209,7 +209,7 @@ export default class ReactQueryParams extends Component {
     const search =
       "?" +
       Object.keys(nextQueryParams)
-        .map(key => `${key}=${nextQueryParams[key]}`)
+        .map(key => `${key}=${encodeURIComponent(nextQueryParams[key])}`)
         .join("&");
 
     if (addHistory) {


### PR DESCRIPTION
When url param contains special symbol (ex, #) setQueryParams do not encode it.

history.push() do not support non-encoded symbols  and trims them